### PR TITLE
[5.0] Code Quality Improvements and Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ Installation and Usage
 **NOTE: Adjust instructions as needed for your local environment**
 
 ### Installation
-*Currently, this Bundle is not available via Composer and must be installed manually into the application*
+Install via Composer
+```shell
+composer require aligent/orocommerce-announcement-bundle
+```
 
-Once installed, clear Oro cache to load bundle, then run a [full asset install](https://doc.oroinc.com/bundles/platform/AssetBundle/commands/#oro-assets-install) to ensure assets are recompiled.
+Once installed, run platform update to perform the installation:
+```shell
+php bin/console oro:platform:update --env=prod
+```
 
 
 ### Configuration Settings
@@ -58,7 +64,9 @@ Roadmap / Remaining Tasks
 -------------------
 - [x] Ability to restrict Announcement to one or more Customer Groups
 - [x] OroCommerce 5.0 Support
-- [ ] Implement Unit Tests
+- [x] Implement Unit Tests
+- [x] Refactor `AnnouncementDataProvider`
+- [ ] Consistent naming of `color` (deprecate `colour`)
 - [ ] Reset `hideAlert` session variable when new Announcements are added
 - [ ] Ability to block dismissal of Announcement Message (hides the 'X' button)
 - [ ] Ability to only display on Homepage

--- a/src/Aligent/AnnouncementBundle/DependencyInjection/AligentAnnouncementExtension.php
+++ b/src/Aligent/AnnouncementBundle/DependencyInjection/AligentAnnouncementExtension.php
@@ -7,22 +7,18 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
-
-
 namespace Aligent\AnnouncementBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class AligentAnnouncementExtension extends Extension
 {
     const ALIAS = 'aligent_announcement';
 
     /**
-     * Loads a specific configuration.
-     *
      * @param array<int,mixed> $configs
      * @param ContainerBuilder $container
      * @throws \Exception

--- a/src/Aligent/AnnouncementBundle/DependencyInjection/Configuration.php
+++ b/src/Aligent/AnnouncementBundle/DependencyInjection/Configuration.php
@@ -7,7 +7,6 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
-
 namespace Aligent\AnnouncementBundle\DependencyInjection;
 
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;

--- a/src/Aligent/AnnouncementBundle/Form/Type/ContentBlockSelectType.php
+++ b/src/Aligent/AnnouncementBundle/Form/Type/ContentBlockSelectType.php
@@ -7,8 +7,6 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
-
-
 namespace Aligent\AnnouncementBundle\Form\Type;
 
 use Doctrine\Persistence\ManagerRegistry;

--- a/src/Aligent/AnnouncementBundle/Form/Type/CustomerGroupMultiSelectType.php
+++ b/src/Aligent/AnnouncementBundle/Form/Type/CustomerGroupMultiSelectType.php
@@ -7,7 +7,6 @@
  * @license
  * @link      http://www.aligent.com.au/
  */
-
 namespace Aligent\AnnouncementBundle\Form\Type;
 
 use Doctrine\Persistence\ObjectManager;

--- a/src/Aligent/AnnouncementBundle/Resources/config/services.yml
+++ b/src/Aligent/AnnouncementBundle/Resources/config/services.yml
@@ -16,7 +16,6 @@ services:
     Aligent\AnnouncementBundle\Layout\DataProvider\AnnouncementDataProvider:
         arguments:
             - '@oro_config.manager'
-            - '@oro_website.manager'
             - '@oro_locale.settings'
             - '@oro_security.token_accessor'
         tags:

--- a/src/Aligent/AnnouncementBundle/Resources/translations/messages.en.yml
+++ b/src/Aligent/AnnouncementBundle/Resources/translations/messages.en.yml
@@ -10,11 +10,11 @@ aligent:
 
             date_start:
                 label: 'Start date'
-                hint: 'Will be used as starting date to display announcement message'
+                hint: 'Will be used as starting date to display announcement message (at midnight in system timezone)'
 
             date_end:
                 label: 'End date'
-                hint: 'Will be used as end date to stop displaying announcement message'
+                hint: 'Will be used as end date to stop displaying announcement message (after 23:59:59pm in system timezone)'
 
             block_alias:
                 label: 'Content block'

--- a/src/Aligent/AnnouncementBundle/Tests/Unit/Layout/DataProvider/AnnouncementDataProviderTest.php
+++ b/src/Aligent/AnnouncementBundle/Tests/Unit/Layout/DataProvider/AnnouncementDataProviderTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * @category  Aligent
+ * @package
+ * @author    Chris Rossi <chris.rossi@aligent.com.au>
+ * @copyright 2022 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+namespace Aligent\AnnouncementBundle\Tests\Unit\Layout\DataProvider;
+
+use Aligent\AnnouncementBundle\DependencyInjection\Configuration;
+use Aligent\AnnouncementBundle\Layout\DataProvider\AnnouncementDataProvider;
+use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Oro\Bundle\CustomerBundle\Entity\Customer;
+use Oro\Bundle\CustomerBundle\Entity\CustomerGroup;
+use Oro\Bundle\CustomerBundle\Entity\CustomerUser;
+use Oro\Bundle\LocaleBundle\Model\LocaleSettings;
+use Oro\Bundle\SecurityBundle\Authentication\TokenAccessorInterface;
+use Oro\Component\Testing\Unit\EntityTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AnnouncementDataProviderTest extends \PHPUnit\Framework\TestCase
+{
+    use EntityTrait;
+
+    protected ConfigManager|MockObject $configManager;
+    protected LocaleSettings|MockObject $localeSettings;
+    protected TokenAccessorInterface|MockObject $tokenAccessor;
+
+    public function setUp(): void
+    {
+        $this->configManager = $this->getMockBuilder(ConfigManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->localeSettings = $this->createMock(LocaleSettings::class);
+        $this->tokenAccessor = $this->createMock(TokenAccessorInterface::class);
+    }
+
+    public function testGetConfiguration(): void
+    {
+        $this->configManager->expects($this->any())
+            ->method('get')
+            ->willReturnMap([
+                ['aligent_announcement.alert_block_alias', false, false, null, 'test-block-alias'],
+                ['aligent_announcement.alert_block_background_colour', false, false, null, '#FFCC00'],
+            ]);
+        ;
+
+        $provider = new AnnouncementDataProvider(
+            $this->configManager,
+            $this->localeSettings,
+            $this->tokenAccessor,
+        );
+
+        $this->assertEquals(
+            'test-block-alias',
+            $provider->getConfiguration(Configuration::ALERT_BLOCK_ALIAS)
+        );
+
+        $this->assertEquals('#FFCC00', $provider->getBackgroundColor());
+    }
+
+    /**
+     * @dataProvider getContrastColorData
+     */
+    public function testGetContrastColor(string $backgroundColor, string $expectedContrastColor): void
+    {
+        $provider = $this->getMockBuilder(AnnouncementDataProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getBackgroundColor'])
+            ->getMock();
+
+        $provider->expects($this->once())
+            ->method('getBackgroundColor')
+            ->willReturn($backgroundColor);
+
+        $contrastColor = $provider->getContrastColor();
+
+        $this->assertEquals($expectedContrastColor, $contrastColor);
+    }
+
+    public function getContrastColorData(): \Generator
+    {
+        yield 'Black background returns White text' => [
+            'backgroundColor' => '#000000',
+            'expectedContrastColor' => '#FFF',
+        ];
+
+        yield 'White background returns Black text' => [
+            'backgroundColor' => '#FFFFFF',
+            'expectedContrastColor' => '#000',
+        ];
+
+        yield 'Dark Blue background returns White text' => [
+            'backgroundColor' => '#20457C',
+            'expectedContrastColor' => '#FFF',
+        ];
+
+        yield 'Light Yellow background returns Black text' => [
+            'backgroundColor' => '#ddc039',
+            'expectedContrastColor' => '#000',
+        ];
+    }
+
+    /**
+     * @dataProvider getDisplayStatusData
+     * @param array<int,array<int,mixed>> $configuration
+     * @param CustomerUser|null $customerUser
+     * @param bool $expectedDisplayStatus
+     */
+    public function testDisplayStatus(
+        array $configuration,
+        ?CustomerUser $customerUser,
+        bool $expectedDisplayStatus,
+    ): void {
+        if ($customerUser) {
+            $this->tokenAccessor->expects($this->any())
+                ->method('getUser')
+                ->willReturn($customerUser);
+        }
+
+        $this->localeSettings->expects($this->any())
+            ->method('getTimeZone')
+            ->willReturn('Australia/Adelaide');
+
+        $provider = $this->getMockBuilder(AnnouncementDataProvider::class)
+            ->setConstructorArgs([$this->configManager, $this->localeSettings, $this->tokenAccessor])
+            ->onlyMethods(['getConfiguration'])
+            ->getMock();
+
+        $provider->expects($this->any())
+            ->method('getConfiguration')
+            ->willReturnMap($configuration);
+
+        $this->assertEquals($expectedDisplayStatus, $provider->getDisplayStatus());
+    }
+
+    public function getDisplayStatusData(): \Generator
+    {
+        $customerGroup = $this->getEntity(CustomerGroup::class, [
+            'id' => 123,
+            'name' => 'CUSTOMER_GROUP',
+        ]);
+
+        $otherCustomerGroup = $this->getEntity(CustomerGroup::class, [
+            'id' => 456,
+            'name' => 'OTHER_CUSTOMER_GROUP',
+        ]);
+
+        $customer = $this->getEntity(Customer::class, [
+            'group' => $customerGroup,
+        ]);
+
+        $customerUser = $this->getEntity(CustomerUser::class, [
+            'customer' => $customer,
+        ]);
+
+        yield 'All Groups, Guest Customer, no Configuration' => [
+            'configuration' => [],
+            'customerUser' => null,
+            'expectedDisplayStatus' => false,
+        ];
+
+        yield 'All Groups, Guest Customer, only Content Block configured' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'All Groups, Guest Customer, no start/end date' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', null],
+                ['alert_block_date_end', null],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'All Groups, Guest Customer, starts today, ends tomorrow' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', new \DateTime('today')],
+                ['alert_block_date_end', new \DateTime('tomorrow')],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'All Groups, Guest Customer, no start date, ends tomorrow' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', null],
+                ['alert_block_date_end', new \DateTime('tomorrow')],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'All Groups, Guest Customer, starts yesterday, no end date' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', new \DateTime('yesterday')],
+                ['alert_block_date_end', null],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'All Groups, Guest Customer, starts tomorrow, no end date' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', new \DateTime('tomorrow')],
+                ['alert_block_date_end', null],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => false,
+        ];
+
+        yield 'All Groups, Guest Customer, starts yesterday, ends today' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', new \DateTime('yesterday')],
+                ['alert_block_date_end', new \DateTime('today')],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'All Groups, Guest Customer, starts last week, ended yesterday' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', []],
+                ['alert_block_date_start', new \DateTime('-7 days')],
+                ['alert_block_date_end', new \DateTime('-1 days')],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => false,
+        ];
+
+        yield 'Specific Customer Group, Guest Customer, no start/end dates' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', [$customerGroup]],
+                ['alert_block_date_start', null],
+                ['alert_block_date_end', null],
+            ],
+            'customerUser' => null,
+            'expectedDisplayStatus' => false,
+        ];
+
+        yield 'Specific Customer Group, Logged-in Customer in same Group, no start/end dates' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', [$customerGroup->getId()]],
+                ['alert_block_date_start', null],
+                ['alert_block_date_end', null],
+            ],
+            'customerUser' => $customerUser,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'Specific Customer Group, Logged-in Customer in different Group, no start/end dates' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', [$otherCustomerGroup->getId()]],
+                ['alert_block_date_start', null],
+                ['alert_block_date_end', null],
+            ],
+            'customerUser' => $customerUser,
+            'expectedDisplayStatus' => false,
+        ];
+
+        yield 'Specific Customer Group, Logged-in Customer in same Group, starts tomorrow, ends next week' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', [$customerGroup->getId()]],
+                ['alert_block_date_start', new \DateTime('tomorrow')],
+                ['alert_block_date_end', new \DateTime('next week')],
+            ],
+            'customerUser' => $customerUser,
+            'expectedDisplayStatus' => false,
+        ];
+
+        yield 'Specific Customer Group, Logged-in Customer in same Group, started yesterday, ends next week' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', [$customerGroup->getId()]],
+                ['alert_block_date_start', new \DateTime('yesterday')],
+                ['alert_block_date_end', new \DateTime('next week')],
+            ],
+            'customerUser' => $customerUser,
+            'expectedDisplayStatus' => true,
+        ];
+
+        yield 'Specific Customer Group, Logged-in Customer in different Group, started yesterday, ends next week' => [
+            'configuration' => [
+                ['alert_block_alias', 'test-content-block'],
+                ['alert_block_allowed_customer_groups', [$otherCustomerGroup->getId()]],
+                ['alert_block_date_start', new \DateTime('yesterday')],
+                ['alert_block_date_end', new \DateTime('next week')],
+            ],
+            'customerUser' => $customerUser,
+            'expectedDisplayStatus' => false,
+        ];
+    }
+}


### PR DESCRIPTION
* Update `README` to include new Composer installation process
* Update Roadmap/Remaining Tasks
* Remove `WebsiteManager` from Layout DataProvider as `configManager` already scopes to Website on the storefront
* Move all Configuration calls to `getConfiguration()` method
* Add new `toSystemTimeZone()` method
* Refactor `checkAlertBlockDatesRange()` method
* Simplify `getContentBlock()` method
* Modify `getDisplayStatus()` to check for Content Block first
* Remove unnecessary conversion from `DateTime` to `string` (`d-m-y`) and then to `Carbon`
* Update admin translations for additional clarity
* Add unit tests for `AnnouncementDataProvider`
* Make private methods protected
* Minor code style and comment improvements