### PR TITLE
[5.1] version requirement & code quality fixes

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPStan

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPStan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPStan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPStan

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPUnit

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
+        php: [8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP-${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }} - PHPUnit

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~9.5.27",
-    "phpstan/phpstan": "^1.7",
+    "phpstan/phpstan": "^1.10",
     "phpmd/phpmd": "~2.13.0",
     "friendsofphp/php-cs-fixer": "~3.13.1",
     "symfony/phpunit-bridge": "~5.4.17",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
     }
   },
   "config": {
-    "bin-dir": "bin"
+    "bin-dir": "bin",
+    "allow-plugins": {
+      "symfony/flex": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   "config": {
     "bin-dir": "bin",
     "allow-plugins": {
-      "symfony/flex": true
+      "symfony/flex": true,
+      "symfony/runtime": true
     }
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "oro/commerce": "5.0.*"
+    "oro/commerce": "5.1.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
     "oro/commerce": "5.1.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "~9.5.27",
     "phpstan/phpstan": "^1.7",
-    "phpmd/phpmd": "^2.12",
-    "friendsofphp/php-cs-fixer": "~2.18.2 || ~2.19.0",
-    "symfony/phpunit-bridge": "~4.4.24 || ~6.1.0",
-    "squizlabs/php_codesniffer": "^3.6"
+    "phpmd/phpmd": "~2.13.0",
+    "friendsofphp/php-cs-fixer": "~3.13.1",
+    "symfony/phpunit-bridge": "~5.4.17",
+    "squizlabs/php_codesniffer": "~3.7.1"
   }
 }

--- a/config/bootstrap_test.php
+++ b/config/bootstrap_test.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+use Oro\Bundle\EntityExtendBundle\Test\EntityExtendTestInitializer;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+(new Dotenv('ORO_ENV', 'ORO_DEBUG'))
+    ->setProdEnvs(['prod', 'behat_test'])
+    ->bootEnv(dirname(__DIR__).'/.env-app', 'prod', ['test']);
+EntityExtendTestInitializer::initialize();

--- a/config/bootstrap_test.php
+++ b/config/bootstrap_test.php
@@ -1,11 +1,7 @@
 <?php
 
-use Symfony\Component\Dotenv\Dotenv;
 use Oro\Bundle\EntityExtendBundle\Test\EntityExtendTestInitializer;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-(new Dotenv('ORO_ENV', 'ORO_DEBUG'))
-    ->setProdEnvs(['prod', 'behat_test'])
-    ->bootEnv(dirname(__DIR__).'/.env-app', 'prod', ['test']);
 EntityExtendTestInitializer::initialize();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
         backupGlobals="false"
         backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
+        bootstrap="config/bootstrap_test.php"
         stopOnError="false"
         stopOnFailure="false"
         stopOnWarning="false"

--- a/src/Aligent/AnnouncementBundle/Form/Type/ContentBlockSelectType.php
+++ b/src/Aligent/AnnouncementBundle/Form/Type/ContentBlockSelectType.php
@@ -48,6 +48,7 @@ class ContentBlockSelectType extends AbstractType
 
                 $contentBlocks = $repo->findAll();
                 $result = [];
+                /** @var ContentBlock $contentBlock */
                 foreach ($contentBlocks as $contentBlock) {
                     $label = $contentBlock->getAlias();
                     $result[$label] = $contentBlock->getAlias();

--- a/src/Aligent/AnnouncementBundle/Layout/DataProvider/AnnouncementDataProvider.php
+++ b/src/Aligent/AnnouncementBundle/Layout/DataProvider/AnnouncementDataProvider.php
@@ -39,9 +39,10 @@ class AnnouncementDataProvider
     /**
      * Get background colour for the alert block for the current website
      */
-    public function getBackgroundColor(): ?string
+    public function getBackgroundColor(): string
     {
-        return $this->getConfiguration(Configuration::ALERT_BLOCK_BACKGROUND_COLOUR);
+        $color = $this->getConfiguration(Configuration::ALERT_BLOCK_BACKGROUND_COLOUR);
+        return is_string($color) ? $color : '';
     }
 
     /**
@@ -122,7 +123,11 @@ class AnnouncementDataProvider
     protected function toSystemTimeZone(Carbon $carbon): Carbon
     {
         $timeZone = new DateTimeZone($this->localeSettings->getTimeZone());
-        return $carbon->tz($timeZone);
+        $carbonTimezone = $carbon->tz($timeZone);
+        if (! $carbonTimezone instanceof Carbon) {
+            throw new \UnexpectedValueException('Expected return type of Carbon');
+        }
+        return $carbonTimezone;
     }
 
     /**
@@ -161,15 +166,20 @@ class AnnouncementDataProvider
      */
     protected function getAllowedCustomerGroupIdsFromConfig(): array
     {
-        return (array)$this->getConfiguration(Configuration::ALERT_BLOCK_ALLOWED_CUSTOMER_GROUPS);
+        $config = $this->getConfiguration(Configuration::ALERT_BLOCK_ALLOWED_CUSTOMER_GROUPS);
+        if (!is_array($config)) {
+            return [];
+        }
+        return $config;
     }
 
     /**
      * Get alert block alias for the current website
      */
-    public function getContentBlock(): ?string
+    public function getContentBlock(): string
     {
-        return $this->getConfiguration(Configuration::ALERT_BLOCK_ALIAS);
+        $contentBlock = $this->getConfiguration(Configuration::ALERT_BLOCK_ALIAS);
+        return is_string($contentBlock) ? $contentBlock : '';
     }
 
     public function getConfiguration(string $key): mixed

--- a/src/Aligent/AnnouncementBundle/Tests/Unit/Layout/DataProvider/AnnouncementDataProviderTest.php
+++ b/src/Aligent/AnnouncementBundle/Tests/Unit/Layout/DataProvider/AnnouncementDataProviderTest.php
@@ -24,9 +24,9 @@ class AnnouncementDataProviderTest extends \PHPUnit\Framework\TestCase
 {
     use EntityTrait;
 
-    protected ConfigManager|MockObject $configManager;
-    protected LocaleSettings|MockObject $localeSettings;
-    protected TokenAccessorInterface|MockObject $tokenAccessor;
+    protected ConfigManager&MockObject $configManager;
+    protected LocaleSettings&MockObject $localeSettings;
+    protected TokenAccessorInterface&MockObject $tokenAccessor;
 
     public function setUp(): void
     {


### PR DESCRIPTION
- Update Oro version requirement to 5.1
- Static analysis (PHPStan) fixes:
  - make type explicit
  - ensure return values match return types
  - simplify nullable string return types to string
  - use PHP 8.1 intersection types for mocked classes